### PR TITLE
Implement Forwarded Headers

### DIFF
--- a/Parlance/Program.cs
+++ b/Parlance/Program.cs
@@ -48,6 +48,7 @@ builder.Services.AddHostedService<ProjectUpdaterService>();
 
 builder.Services.Configure<ParlanceOptions>(builder.Configuration.GetSection("Parlance"));
 builder.Services.Configure<RateLimitingOptions>(builder.Configuration.GetSection("rateLimiting"));
+builder.Services.Configure<ForwardedHeadersOptions>(builder.Configuration.GetSection("ForwardedHeaders"));
 
 SqliteConnection? connection = null;
 
@@ -119,6 +120,8 @@ if (!app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseForwardedHeaders();
 
 app.UseHttpsRedirection();
 app.UseResponseCompression();

--- a/Parlance/appsettings.json
+++ b/Parlance/appsettings.json
@@ -26,5 +26,8 @@
     "PermitLimit": 8000,
     "Window": 3600,
     "SegmentsPerWindow": 4
+  },
+  "ForwardedHeaders": {
+    "ForwardLimit": 0
   }
 }


### PR DESCRIPTION
Allow Parlance to read the X-Forwarded-For header in the event that Parlance is behind a reverse proxy