### PR TITLE
Base Docker image on Alpine

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,6 @@ name: Publish to GitHub Container Registry
 
 on:
   push:
-    branches:
-      - 'main'
   pull_request:
 
 env:

--- a/Parlance/Dockerfile
+++ b/Parlance/Dockerfile
@@ -1,16 +1,29 @@
-﻿FROM archlinux AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-#RUN echo "Server=https://archive.archlinux.org/repos/2022/11/01/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS native-build
 
-FROM archlinux AS build
+RUN apk add git cmake ninja build-base openssl-dev
+WORKDIR /src
+RUN git clone --branch libssh2-1.11.0 --depth 1 https://github.com/libssh2/libssh2.git
+RUN git clone --branch v1.7.0 --depth 1 https://github.com/libgit2/libgit2.git
 
-#RUN echo "Server=https://archive.archlinux.org/repos/2022/11/01/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist
+WORKDIR /src/libssh2
+RUN cmake -B /build/libssh2 -GNinja -DBUILD_STATIC=OFF -DBUILD_SHARED=ON && cmake --build /build/libssh2 && cmake --install /build/libssh2
+
+WORKDIR /src/libgit2
+RUN cmake -B /build/libgit2 -GNinja -DUSE_SSH=ON -DBUILD_TESTS=OFF && cmake --build /build/libgit2 && cmake --install /build/libgit2
+
+FROM native-build AS native-build-output
+RUN mkdir -p /output
+RUN cp /usr/local/lib/*.so* /output/
+
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
 
 # Install Node.js
-RUN pacman -Syyu --noconfirm nodejs dotnet-runtime dotnet-sdk aspnet-targeting-pack npm && rm -rf /var/lib/pacman/sync
+RUN apk add nodejs npm
 
 WORKDIR /src
 COPY ["Parlance/Parlance.csproj", "Parlance/"]
@@ -24,9 +37,14 @@ RUN dotnet publish "Parlance.csproj" -c Release -o /app/publish
 
 FROM base AS final
 
-# Install libgit2
-RUN pacman -Syy --noconfirm libgit2 dotnet-runtime aspnet-runtime && rm -rf /var/lib/pacman/sync
+# Install openssl
+RUN apk add libcrypto3
+
+WORKDIR /opt/local-libs
+COPY --from=native-build-output /output ./
 
 WORKDIR /app
 COPY --from=publish /app/publish .
+
+ENV LD_LIBRARY_PATH=/opt/local-libs
 ENTRYPOINT ["dotnet", "Parlance.dll"]

--- a/Parlance/Dockerfile
+++ b/Parlance/Dockerfile
@@ -38,7 +38,7 @@ RUN dotnet publish "Parlance.csproj" -c Release -o /app/publish
 FROM base AS final
 
 # Install openssl
-RUN apk add libcrypto3
+RUN apk add libcrypto3 icu
 
 WORKDIR /opt/local-libs
 COPY --from=native-build-output /output ./


### PR DESCRIPTION
Alpine gives us a smaller base than Arch to start off on. This allows the container to be a little bit smaller.