### PR TITLE
Use Dynamic Viewport Height instead of Viewport Height

### DIFF
--- a/Parlance/ClientApp/src/App.module.css
+++ b/Parlance/ClientApp/src/App.module.css
@@ -4,6 +4,6 @@
     align-items: center;
     justify-content: center;
 
-    width: 100vw;
-    height: 100vh;
+    width: 100dvw;
+    height: 100dvh;
 }

--- a/Parlance/ClientApp/src/components/Layout.module.css
+++ b/Parlance/ClientApp/src/components/Layout.module.css
@@ -1,6 +1,6 @@
 .rootLayout {
-    height: 100vh;
-    max-height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
 
     display: grid;
     grid-template-columns: 1fr;


### PR DESCRIPTION
This PR changes the CSS to use the `dvh` unit instead of the `vh` unit, allowing the website to function correctly on browsers where the window chrome can change size.