### PR TITLE
Add text output to console

### DIFF
--- a/Parlance.CldrData/CldrExtensions.cs
+++ b/Parlance.CldrData/CldrExtensions.cs
@@ -28,7 +28,22 @@ public static class CldrExtensions
         
     public static async Task<IServiceCollection> AddCldrAsync(this IServiceCollection services, IConfiguration configuration)
     {
-        await Cldr.Instance.DownloadLatestAsync();
+        var currentVersion = Cldr.Instance.CurrentVersion();
+        Console.WriteLine($"Current CLDR data version: {currentVersion}");
+        var latestVersion = await Cldr.LatestVersionAsync();
+        Console.WriteLine($"Latest CLDR data version: {latestVersion}");
+        
+        if (currentVersion < latestVersion)
+        {
+            Console.WriteLine("Updating CLDR data. This may take some time.");
+            await Cldr.Instance.DownloadAsync(latestVersion);
+            Console.WriteLine("CLDR data was updated.");
+        }
+        else
+        {
+            Console.WriteLine("The CLDR data is up to date.");
+        }
+
         return services;
     }
 

--- a/Parlance/Program.cs
+++ b/Parlance/Program.cs
@@ -25,6 +25,16 @@ using Parlance.Vicr123Accounts.Services.AttributionConsent;
 using Quartz;
 using ServiceReference;
 
+Console.WriteLine("""
+ _____ _   ____________________________________
+|     \ /   |  _ \   _ __| |    _ __ ___|  __|
+| ____//    |  __/-'| '__| /--'| '_ / __|  __|
+| |\  /     | || [] | [  || [] | | [ [__| [__
+|_| \/(_)  _|_| \___|_|__|_\___|_| |\___|____|_
+
+========================================
+""");
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.


### PR DESCRIPTION
This PR introduces a heading in console output when Parlance starts up, and gives information about the current status of the CLDR data.