### PR TITLE
When cloning update database with existing entries

### DIFF
--- a/Parlance.Notifications/Channels/TranslationFreeze/TranslationFreezeTranslationSubmitEventAutoSubscription.cs
+++ b/Parlance.Notifications/Channels/TranslationFreeze/TranslationFreezeTranslationSubmitEventAutoSubscription.cs
@@ -33,6 +33,11 @@ public class TranslationFreezeTranslationSubmitEventAutoSubscription(
     {
         await using var scope = serviceProvider.CreateAsyncScope();
         var notificationService = scope.ServiceProvider.GetRequiredService<INotificationService>();
+
+        if (message.User is null)
+        {
+            return;
+        }
         
         var subscription = await notificationService.GetAutoSubscriptionPreference<TranslationFreezeTranslationSubmitEventAutoSubscription, TranslationFreezeNotificationChannel>(message.User.Id);
         if (!subscription.IsSubscribed)

--- a/Parlance.Project/Events/TranslationSubmitEvent.cs
+++ b/Parlance.Project/Events/TranslationSubmitEvent.cs
@@ -7,7 +7,7 @@ public class TranslationSubmitEvent
 {
     public required IParlanceSubprojectLanguage SubprojectLanguage { get; set; }
     public required IParlanceTranslationFileEntry Entry { get; set; }
-    public required User User { get; set; }
+    public required User? User { get; set; }
     
     public required Database.Models.Project Project { get; set; }
 }

--- a/Parlance.VersionControl/Services/PendingEdits/PendingEditsTranslationSubmitEventWatcher.cs
+++ b/Parlance.VersionControl/Services/PendingEdits/PendingEditsTranslationSubmitEventWatcher.cs
@@ -26,6 +26,12 @@ public class PendingEditsTranslationSubmitEventWatcher(
 
     public async ValueTask HandleAsync(TranslationSubmitEvent message, CancellationToken cancellationToken)
     {
+        // If the user is null, we're handling a translation for the first time so there's nothing to change here
+        if (message.User == null)
+        {
+            return;
+        }
+        
         await using var scope = serviceProvider.CreateAsyncScope();
         var pendingEditsService = scope.ServiceProvider.GetRequiredService<IPendingEditsService>();
         await pendingEditsService.RecordPendingEdit(message.SubprojectLanguage, message.User);


### PR DESCRIPTION
This PR ensuers that Parlance registers source strings in its database after cloning so that any later edited strings show up in diffs.